### PR TITLE
Add missing s3:PutBucketAcl to terraform

### DIFF
--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -734,6 +734,7 @@ def create_terraform_policy(role_type):
                         Action("s3", "PutObject"),
                         Action("s3", "DeleteObject"),
                         Action("s3", "PutObjectAcl"),
+                        Action("s3", "PutBucketAcl"),
                         Action("s3", "PutBucketLogging"),
                         Action("s3", "PutBucketVersioning"),
                         Action("s3", "PutBucketCORS"),

--- a/union-ai-admin/aws/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/unionai-provisioner-role.template.yaml
@@ -383,6 +383,7 @@ Resources:
               - s3:PutObject
               - s3:DeleteObject
               - s3:PutObjectAcl
+              - s3:PutBucketAcl
               - s3:PutBucketLogging
               - s3:PutBucketVersioning
               - s3:PutBucketCORS

--- a/union-ai-admin/aws/unionai-updater-role.template.yaml
+++ b/union-ai-admin/aws/unionai-updater-role.template.yaml
@@ -204,6 +204,7 @@ Resources:
               - s3:PutObject
               - s3:DeleteObject
               - s3:PutObjectAcl
+              - s3:PutBucketAcl
               - s3:PutBucketLogging
               - s3:PutBucketVersioning
               - s3:PutBucketCORS


### PR DESCRIPTION
Adds another missing permission, as found when trying to use the original permission set to set up a new cluster.