### PR TITLE
Remove unnecessary Cloudfront permissions

### DIFF
--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -102,17 +102,6 @@ def create_read_policy(role_type):
                 Statement(
                     Effect=Allow,
                     Action=[
-                        Action("cloudfront", "GetCloudFrontOriginAccessIdentity"),
-                    ],
-                    Resource=[
-                        Sub(
-                            "arn:aws:cloudfront::${AWS::AccountId}:origin-access-identity/*"
-                        )
-                    ],
-                ),
-                Statement(
-                    Effect=Allow,
-                    Action=[
                         Action("s3", "ListBucket"),
                         Action("s3", "GetEncryptionConfiguration"),
                         Action("s3", "GetBucketLogging"),
@@ -470,18 +459,6 @@ def create_provisioner_policy(role_type):
                         Sub(
                             "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/eks/opta-*:*"
                         ),
-                    ],
-                ),
-                Statement(
-                    Effect=Allow,
-                    Action=[
-                        Action("cloudfront", "CreateCloudFrontOriginAccessIdentity"),
-                        Action("cloudfront", "DeleteCloudFrontOriginAccessIdentity"),
-                    ],
-                    Resource=[
-                        Sub(
-                            "arn:aws:cloudfront::${AWS::AccountId}:origin-access-identity/*"
-                        )
                     ],
                 ),
                 Statement(

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -286,14 +286,6 @@ Resources:
               - 'elasticache:DeleteCacheSubnetGroup'
             Resource:
               - !Sub 'arn:aws:elasticache:${AWS::Region}:${AWS::AccountId}:subnetgroup:opta-*'
-          - Sid: Cloudfront
-            Effect: Allow
-            Action:
-              - 'cloudfront:CreateCloudFrontOriginAccessIdentity'
-              - 'cloudfront:GetCloudFrontOriginAccessIdentity'
-              - 'cloudfront:DeleteCloudFrontOriginAccessIdentity'
-            Resource:
-              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:origin-access-identity/*'
           - Sid: 'self0'
             Effect: Allow
             Action:


### PR DESCRIPTION
We recently made a change internally that removes the Terraform code that tries to manage these resources.  We should no longer need these permissions.