### PR TITLE
Allow tagging launch templates

### DIFF
--- a/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
@@ -503,5 +503,11 @@ Resources:
             Effect: Allow
             Resource:
               - '*'
+          - Action:
+              - ec2:CreateTags
+              - ec2:DeleteTags
+            Effect: Allow
+            Resource:
+              - arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
@@ -508,6 +508,6 @@ Resources:
               - ec2:DeleteTags
             Effect: Allow
             Resource:
-              - arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*'
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
@@ -509,5 +509,6 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*'
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
@@ -332,5 +332,6 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*'
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
@@ -331,6 +331,6 @@ Resources:
               - ec2:DeleteTags
             Effect: Allow
             Resource:
-              - arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*'
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
@@ -326,5 +326,11 @@ Resources:
             Effect: Allow
             Resource:
               - '*'
+          - Action:
+              - ec2:CreateTags
+              - ec2:DeleteTags
+            Effect: Allow
+            Resource:
+              - arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
         Version: '2012-10-17'
     Type: AWS::IAM::ManagedPolicy

--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -431,6 +431,13 @@ def create_updater_policy(role_type):
                     ],
                     Resource=["*"],
                 ),
+                Statement(
+                    Effect=Allow,
+                    Action=[Action("ec2", "CreateTags"), Action("ec2", "DeleteTags")],
+                    Resource=[
+                        "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*"
+                    ],
+                ),
             ],
         ),
     )

--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -437,7 +437,8 @@ def create_updater_policy(role_type):
                     Resource=[
                         Sub(
                             "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*"
-                        )
+                        ),
+                        Sub("arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"),
                     ],
                 ),
             ],

--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -435,7 +435,9 @@ def create_updater_policy(role_type):
                     Effect=Allow,
                     Action=[Action("ec2", "CreateTags"), Action("ec2", "DeleteTags")],
                     Resource=[
-                        "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*"
+                        Sub(
+                            "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*"
+                        )
                     ],
                 ),
             ],


### PR DESCRIPTION
Allows the `unionai-{provisioner,updater}` roles to create and delete tags on EC2 Launch Templates.  This is necessary as the provider is attempting to automatically tag these templates with `ManagedByUnion=true`.

Unfortunately due to the non-deterministic naming behavior of launch template ARNs, we're unable to scope this down any further.