### PR TITLE
Add permissions to union-ai-admin and union-provisioner for Karpenter

### DIFF
--- a/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
@@ -36,6 +36,24 @@ Resources:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group::log-stream*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/eks/opta-*:*'
           - Action:
+              - sqs:CreateQueue
+              - sqs:DeleteQueue
+              - sqs:SetQueueAttributes
+              - sqs:TagQueue
+              - sqs:UntagQueue
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
+          - Action:
+              - events:DeleteRule
+              - events:PutRule
+              - events:PutTargets
+              - events:RemoveTargets
+              - events:TagResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
+          - Action:
               - ec2:AllocateAddress
               - ec2:AttachInternetGateway
               - ec2:DetachInternetGateway
@@ -242,6 +260,19 @@ Resources:
               - arn:aws:s3:::union-*
               - arn:aws:s3:::union-*/*
           - Action:
+              - events:DescribeRule
+              - events:ListTargetsByRule
+              - events:ListTagsForResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
+          - Action:
+              - sqs:GetQueueAttributes
+              - sqs:ListQueueTags
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
+          - Action:
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:DescribeScalingActivities
               - autoscaling:DescribeTags
@@ -260,7 +291,6 @@ Resources:
           - Action:
               - eks:ListTagsForResource
               - eks:ListNodegroups
-              - eks:ListTagsForResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/opta-*'

--- a/union-ai-admin/aws/gen/unionai-support-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-support-role.template.yaml
@@ -62,6 +62,19 @@ Resources:
               - arn:aws:s3:::union-*
               - arn:aws:s3:::union-*/*
           - Action:
+              - events:DescribeRule
+              - events:ListTargetsByRule
+              - events:ListTagsForResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
+          - Action:
+              - sqs:GetQueueAttributes
+              - sqs:ListQueueTags
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
+          - Action:
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:DescribeScalingActivities
               - autoscaling:DescribeTags
@@ -80,7 +93,6 @@ Resources:
           - Action:
               - eks:ListTagsForResource
               - eks:ListNodegroups
-              - eks:ListTagsForResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/opta-*'

--- a/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-updater-role.template.yaml
@@ -65,6 +65,19 @@ Resources:
               - arn:aws:s3:::union-*
               - arn:aws:s3:::union-*/*
           - Action:
+              - events:DescribeRule
+              - events:ListTargetsByRule
+              - events:ListTagsForResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
+          - Action:
+              - sqs:GetQueueAttributes
+              - sqs:ListQueueTags
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
+          - Action:
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:DescribeScalingActivities
               - autoscaling:DescribeTags
@@ -83,7 +96,6 @@ Resources:
           - Action:
               - eks:ListTagsForResource
               - eks:ListNodegroups
-              - eks:ListTagsForResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/opta-*'

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -283,6 +283,9 @@ Resources:
               - 'logs:DescribeLogStreams'
               - 'iam:ListRoles'
               - 'iam:ListPolicies'
+              - 'ec2:DescribeInstanceTypes'
+              - 'servicequotas:GetServiceQuota'
+              - 'cloudwatch:GetMetricStatistics'
             Resource: '*'
           - Sid: VisualEditor13
             Effect: Allow

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -67,6 +67,26 @@ Resources:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:opta-*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group::log-stream*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/eks/opta-*:*'
+          - Action:
+              - sqs:CreateQueue
+              - sqs:DeleteQueue
+              - sqs:SetQueueAttributes
+              - sqs:TagQueue
+              - sqs:UntagQueue
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
+          - Action:
+              - events:DescribeRule
+              - events:DeleteRule
+              - events:ListTargetsByRule
+              - events:PutRule
+              - events:PutTargets
+              - events:RemoveTargets
+              - events:TagResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
           - Sid: '112'
             Effect: Allow
             Action:
@@ -188,6 +208,8 @@ Resources:
             Effect: Allow
             Action:
               - 'iam:CreatePolicy'
+              - 'iam:CreatePolicyVersion'
+              - 'iam:DeletePolicyVersion'
               - 'iam:GetPolicyVersion'
               - 'iam:GetPolicy'
               - 'iam:ListPolicyVersions'
@@ -275,6 +297,19 @@ Resources:
               - 'arn:aws:s3:::opta-*/'
               - 'arn:aws:s3:::union-*'
               - 'arn:aws:s3:::union-*/'
+          - Action:
+              - events:DescribeRule
+              - events:ListTargetsByRule
+              - events:ListTagsForResource
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'
+          - Action:
+              - sqs:GetQueueAttributes
+              - sqs:ListQueueTags
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:Karpenter*'
           - Sid: ElastiCache
             Effect: Allow
             Action:
@@ -297,6 +332,7 @@ Resources:
               - 'iam:UntagInstanceProfile'
               - 'iam:ListInstanceProfileTags'
               - 'iam:GetInstanceProfile'
+              - 'iam:UpdateAssumeRolePolicy'
             Resource:
               - !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/*'
           - Sid: 'self1'


### PR DESCRIPTION
Adds the permissions to provision Karpenter and its corresponding SQS queues and EventBridge rules. Does not contain the permissions to run Karpenter itself.

While here, also add missing DescribeInstanceTypes permissions to union-ai-admin.

Tested on acme cluster.