### PR TITLE
INFRA-452 "Interface" VPC Endpoint permissions for union-ai-admin AWS

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -408,6 +408,7 @@ Resources:
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc-endpoint/*'
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*'
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*'
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*'
           - Sid: 'AllowVpcEndpointReadPermissions'
             Effect: Allow
             Action:


### PR DESCRIPTION
VPC Endpoints only support Cloudwatch logs through VPC Endpoint Interfaces. The VPC endpoint is managed at the Security Group + ENI level. The VPC Endpoint is added to the Security Group. 

We haven't approached this in the past because S3 and Dynamo DB are managed through VPC Endpoint Gateways. 