### PR TITLE
AWS union-ai-admin Add ability to untag Karpenter event resources

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -304,6 +304,7 @@ Resources:
               - events:DescribeRule
               - events:ListTargetsByRule
               - events:ListTagsForResource
+              - events:UntagResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'


### PR DESCRIPTION
Currently missing permission to be able to remove default_tags.