### PR TITLE
Add permission to union-ai-admin to manage EKS access entries

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -85,6 +85,10 @@ Resources:
               - 'eks:TagResource'
               - 'eks:UntagResource'
               - 'eks:ListTagsForResource'
+              - 'eks:CreateAccessEntry'
+              - 'eks:DescribeAccessEntry'
+              - 'eks:UpdateAccessEntry'
+              - 'eks:DeleteAccessEntry'
             Resource:
               - !Sub 'arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/opta-*'
           - Sid: '1'
@@ -296,7 +300,6 @@ Resources:
               - events:DescribeRule
               - events:ListTargetsByRule
               - events:ListTagsForResource
-              - events:UntagResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -300,6 +300,7 @@ Resources:
               - events:DescribeRule
               - events:ListTargetsByRule
               - events:ListTagsForResource
+              - events:UntagResource
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/Karpenter*'


### PR DESCRIPTION
Adds permission to allow the management of EKS access entries. Access entries can be used to allow IAM roles or users access to Kubernetes objects without using aws-auth.