### PR TITLE
Allow associating additional CIDR blocks to VPC

### DIFF
--- a/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
+++ b/union-ai-admin/aws/gen/unionai-provisioner-role.template.yaml
@@ -78,6 +78,7 @@ Resources:
               - ec2:DeleteFlowLogs
               - ec2:CreateFlowLogs
               - ec2:CreateVpc
+              - ec2:AssociateVpcCidrBlock
               - ec2:ReleaseAddress
               - ec2:CreateTags
               - ec2:RunInstances

--- a/union-ai-admin/aws/script/generate.py
+++ b/union-ai-admin/aws/script/generate.py
@@ -546,6 +546,7 @@ def create_provisioner_policy(role_type):
                         Action("ec2", "DeleteFlowLogs"),
                         Action("ec2", "CreateFlowLogs"),
                         Action("ec2", "CreateVpc"),
+                        Action("ec2", "AssociateVpcCidrBlock"),
                         Action("ec2", "ReleaseAddress"),
                         Action("ec2", "CreateTags"),
                         Action("ec2", "RunInstances"),

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -187,6 +187,7 @@ Resources:
               - 'ec2:DeleteVpc'
               - 'ec2:CreateSubnet'
               - 'ec2:DescribeVpcAttribute'
+              - 'ec2:AssociateVpcCidrBlock'
             Resource:
               - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*'
           - Sid: VisualEditor9


### PR DESCRIPTION
This allows us to attach additional CIDR blocks to a VPC, allowing us to grow beyond the current `/21` default CIDR block size per subnet.