### PR TITLE
Add artifactregistry.repositories.uploadArtifact to GCP unionai-admin role

### DIFF
--- a/union-ai-admin/gcp/union-ai-admin-role.yaml
+++ b/union-ai-admin/gcp/union-ai-admin-role.yaml
@@ -1,6 +1,7 @@
 title: Unionai Administrator
 stage: GA
 includedPermissions:
+- artifactregistry.repositories.createOnPush
 - artifactregistry.repositories.uploadArtifacts
 - cloudkms.cryptoKeyVersions.destroy
 - cloudkms.cryptoKeyVersions.list

--- a/union-ai-admin/gcp/union-ai-admin-role.yaml
+++ b/union-ai-admin/gcp/union-ai-admin-role.yaml
@@ -1,6 +1,7 @@
 title: Unionai Administrator
 stage: GA
 includedPermissions:
+- artifactregistry.repositories.uploadArtifacts
 - cloudkms.cryptoKeyVersions.destroy
 - cloudkms.cryptoKeyVersions.list
 - cloudkms.cryptoKeys.create


### PR DESCRIPTION
* This allows us to create `google_container_registry` terraform
  resource to ensure gcr.io backing bucket exists.

This appears to be a new permission requirement. Likely relates to the
migration to artifact registry and deprecation of container_registry.
