### PR TITLE
Reduce Cloudwatch logs permissions

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -367,9 +367,7 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Action:
-              - logs:GetLogRecord
               - logs:GetLogEvents
-              - logs:FilterLogEvents
             Resource:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/eks/opta-*:log-stream:kube-*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/dataplane:log-stream:*'


### PR DESCRIPTION
Reduce Cloudwatch logs permissions in union-ai-admin role. These permissions were not required to allow access to CloudWatch log events in a limited number of log streams. 

PE-1160