### PR TITLE
GCP Image builder permissions

### DIFF
--- a/union-ai-admin/gcp/union-ai-admin-role.yaml
+++ b/union-ai-admin/gcp/union-ai-admin-role.yaml
@@ -1,6 +1,21 @@
 title: Unionai Administrator
 stage: GA
 includedPermissions:
+- artifactregistry.repositories.create
+- artifactregistry.repositories.createTagBinding
+- artifactregistry.repositories.delete
+- artifactregistry.repositories.deleteArtifacts
+- artifactregistry.repositories.deleteTagBinding
+- artifactregistry.repositories.downloadArtifacts
+- artifactregistry.repositories.get
+- artifactregistry.repositories.getIamPolicy
+- artifactregistry.repositories.list
+- artifactregistry.repositories.listEffectiveTags
+- artifactregistry.repositories.listTagBindings
+- artifactregistry.repositories.readViaVirtualRepository
+- artifactregistry.repositories.setIamPolicy
+- artifactregistry.repositories.update
+- artifactregistry.repositories.uploadArtifacts
 - cloudkms.cryptoKeyVersions.destroy
 - cloudkms.cryptoKeyVersions.list
 - cloudkms.cryptoKeys.create


### PR DESCRIPTION
* Provide the ability for union-admin GSA to create artifact
  repositories to be used with Union remote image builder.
