### PR TITLE
Update AWS union admin role for BYOC Image Builder

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -398,6 +398,11 @@ Resources:
             Resource:
               - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/union/*'
               - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/cloud/*' # TODO(Mike): Move cloud-task in union namespace
+          - Sid: 'UnionAdminAuthToken'
+            Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+            Resource: '*'
 Metadata:
   'AWS::CloudFormation::Designer': {}
 Outputs:

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -374,6 +374,30 @@ Resources:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/host:log-stream:*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/application:log-stream:fluentbit-kube.var.log.containers.union-operator-*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/application:log-stream:fluentbit-kube.var.log.containers.flytepropeller-*'
+          - Sid: 'UnionImageBuilderRepoAdmin'
+            Effect: Allow
+            Action:
+              - ecr:CreateRepository
+              - ecr:DeleteRepository
+              - ecr:TagResource
+              - ecr:UntagResource
+              - ecr:PutLifecyclePolicy
+              - ecr:DeleteLifecyclePolicy
+              - ecr:PutImageTagMutability
+              - ecr:PutImageScanningConfiguration
+              - ecr:BatchDeleteImage
+              - ecr:DeleteRepositoryPolicy
+              - ecr:SetRepositoryPolicy
+              - ecr:GetRepositoryPolicy
+              - ecr:PutReplicationConfiguration
+              - ecr:DescribeRepositories
+              - ecr:ListTagsForResource
+              - ecr:GetLifecyclePolicy
+              - ecr:GetRepositoryPolicy
+              - ecr:DescribeImages
+            Resource:
+              - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/union/*'
+              - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/cloud/*' # TODO(Mike): Move cloud-task in union namespace
 Metadata:
   'AWS::CloudFormation::Designer': {}
 Outputs:

--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -397,7 +397,6 @@ Resources:
               - ecr:DescribeImages
             Resource:
               - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/union/*'
-              - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/cloud/*' # TODO(Mike): Move cloud-task in union namespace
           - Sid: 'UnionAdminAuthToken'
             Effect: Allow
             Action:


### PR DESCRIPTION
Add support for provisioning Union remote image builder. Specifically the ability fully managed `union` prefixed ECR repositories and have union-admin role publish default images.