### PR TITLE
Update permissions to delete service connections on Data plane deletion

### DIFF
--- a/union-ai-admin/gcp/union-ai-project-editor-role.yaml
+++ b/union-ai-admin/gcp/union-ai-project-editor-role.yaml
@@ -450,4 +450,5 @@ includedPermissions:
 - resourcemanager.projects.setIamPolicy
 - servicenetworking.operations.get
 - servicenetworking.services.addPeering
+- servicenetworking.services.deleteConnection
 - servicenetworking.services.get


### PR DESCRIPTION
This permissions is required for deleting a service connection required for adding additional pod ranges to VPCs