### PR TITLE
Add `servicenetworking.services.deleteConnection` to GCP union-ai-admin role

### DIFF
--- a/union-ai-admin/gcp/union-ai-admin-role.yaml
+++ b/union-ai-admin/gcp/union-ai-admin-role.yaml
@@ -526,6 +526,7 @@ includedPermissions:
 - secretmanager.versions.list
 - servicenetworking.operations.get
 - servicenetworking.services.addPeering
+- servicenetworking.services.deleteConnection
 - servicenetworking.services.get
 - storage.buckets.create
 - storage.buckets.delete


### PR DESCRIPTION
Only added it to the editor role before. Need to add to the admin role.