### PR TITLE
ctx/chore: update log groups for enhanced logging

### DIFF
--- a/union-ai-admin/aws/union-ai-admin-role.template.yaml
+++ b/union-ai-admin/aws/union-ai-admin-role.template.yaml
@@ -365,10 +365,12 @@ Resources:
           - Effect: Allow
             Action:
               - logs:GetLogEvents
+              - logs:FilterLogEvents
             Resource:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/eks/opta-*:log-stream:kube-*'
-              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/dataplane:log-stream:*'
-              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/host:log-stream:*'
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/union/cluster-*/dataplane:log-stream:*'
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/union/cluster-*/host:log-stream:*'
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/union/cluster-*/task:log-stream:*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/application:log-stream:fluentbit-kube.var.log.containers.union-operator-*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/containerinsights/opta-*/application:log-stream:fluentbit-kube.var.log.containers.flytepropeller-*'
           - Sid: 'UnionImageBuilderRepoAdmin'


### PR DESCRIPTION
* [x] Restricts access to only the log groups that contain node level logs for union managed instances.
* [x] Add filter logs permissions to optimize access during troubleshooting.