### PR TITLE
add compute.globalAddresses.setLabels

### DIFF
--- a/union-ai-admin/gcp/union-ai-admin-role.yaml
+++ b/union-ai-admin/gcp/union-ai-admin-role.yaml
@@ -65,6 +65,7 @@ includedPermissions:
 - compute.globalAddresses.createInternal
 - compute.globalAddresses.deleteInternal
 - compute.globalAddresses.get
+- compute.globalAddresses.setLabels
 - compute.globalOperations.get
 - compute.healthChecks.create
 - compute.healthChecks.delete


### PR DESCRIPTION
add compute.globalAddresses.setLabels to the union-ai-admin-role.yaml

was missing here: https://buildkite.com/unionai/managed-cluster-staging-sync/builds/9707#019978e8-c8cf-4020-b9d2-c865958ef868